### PR TITLE
Add new components for basic attribute fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "react-autosize-textarea": "^3.0.1",
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",
-    "react-select": "^1.1.0",
     "react-sizeme": "^2.3.6",
     "react-wp-scripts": "^0.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "react": "^16.2.0",
     "react-autosize-textarea": "^3.0.1",
+    "react-color": "^2.13.8",
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",
     "react-sizeme": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "dependencies": {
     "react": "^16.2.0",
+    "react-autosize-textarea": "^3.0.1",
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",
+    "react-select": "^1.1.0",
+    "react-sizeme": "^2.3.6",
     "react-wp-scripts": "^0.1.1"
   },
   "scripts": {

--- a/src/EditBlock.css
+++ b/src/EditBlock.css
@@ -18,9 +18,6 @@
 .wp-block-shortcake-preview-overlay.editing {
 	background-color: rgba( 255, 255, 255, 0.9 );
 	border: 2px solid rgba( 0, 0, 0, 0.6 );
-}
-
-.wp-block-shortcode-edit-form {
 	width: 100%;
 	height: 100%;
 	padding: 0;
@@ -32,6 +29,12 @@
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
+.wp-block-shortcode-edit-form {
+	width: 60%;
+	margin-top: 2em;
+	flex: 1;
+}
+
 .shortcode-ui-block-editor-title {
 	position: absolute;
 	top: 0;
@@ -41,11 +44,6 @@
 	padding: 3px 20%;
 	background-color: rgba( 0, 0, 0, 0.6 );
 	color: #fff;
-}
-
-.shortcode-ui-block-editor-content {
-	width: 60%;
-	margin-top: 2em;
 }
 
 .shortcode-ui-block-inspector-form-item-label, .shortcode-ui-block-inspector-form-item-description {
@@ -71,7 +69,7 @@
 	color: #999;
 	padding: 3px 0;
 }
-.shortcode-ui-block-inspector-form-item:not(:last-child) {
+.shortcode-ui-block-inspector-form-item:not(:last-of-type) {
 	border-bottom: 1px solid #ccc;
 	margin-bottom: 10px;
 }

--- a/src/EditBlock.css
+++ b/src/EditBlock.css
@@ -82,3 +82,17 @@
 	display: block;
 	break-inside: avoid;
 }
+
+.shortcode-ui-form-range-input {
+	max-width: 225px;
+	display: inline-block;
+	margin-right: 12px;
+	vertical-align: middle;
+}
+
+.shortcode-ui-form-range-label {
+	font-size: 12px;
+	line-height: 30px;
+	vertical-align: middle;
+}
+

--- a/src/EditBlock.css
+++ b/src/EditBlock.css
@@ -74,4 +74,11 @@
 	margin-bottom: 10px;
 }
 
+.shortcode-ui-form-radio-options-wrapper {
+	columns: 100px 4;
+}
 
+.shortcode-ui-form-radio-option-label {
+	display: block;
+	break-inside: avoid;
+}

--- a/src/EditBlock.js
+++ b/src/EditBlock.js
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import Fetcher from './utils/Fetcher';
+import EditAttributeField from './fields/EditAttributeField';
 
 import './EditBlock.css'
 
@@ -26,8 +27,6 @@ class EditBlock extends Component {
 
 		this.shortcode = shortcode;
 		this.state = { content: '', preview: '' };
-
-		this.renderTextField = this.renderTextField.bind( this );
 
 		this.updatePreview = this.updatePreview.bind( this );
 		this.maybeUpdatePreview = _.throttle( this.updatePreview, 300 );
@@ -87,10 +86,23 @@ class EditBlock extends Component {
 		const { SandBox } = wp.components;
 
 		const { attrs, label, shortcode_tag } = this.shortcode;
-		const { focus, setFocus } = this.props;
+		const { attributes, setAttributes, focus, setFocus } = this.props;
 		const { content, preview } = this.state;
 
-		const editForm = attrs.map( attr => this.renderTextField( attr ) );
+		const editForm = attrs.map(
+			attribute => {
+				const { attr } = attribute;
+				const { [ attr ]: value } = attributes;
+				return (
+					<EditAttributeField
+						attribute={ attribute }
+						shortcode={ this.shortcode }
+						value={ value }
+						updateValue={ newValue => setAttributes( { [ attr ]: newValue } ) }
+						/>
+				);
+			}
+		);
 
 		return [
 			preview ?
@@ -134,43 +146,6 @@ class EditBlock extends Component {
 			]
 		];
 	}
-
-	/**
-	 * Render a text input for an attribute value field.
-	 *
-	 * TODO: This should be moved to a different component so that we
-	 * can define multiple input types. Currently all attribute fields
-	 * are displayed as text inputs, no matter what field type was
-	 * registered for them.
-	 *
-	 * @param  {Object}            attribute  Attribute field as defined in shortcode UI.
-	 * @return {wp.blocks.element}            HTML for section with label, input, and description if available.
-	 */
-	renderTextField( attribute ) {
-		const { attr, label, description } = attribute;
-		const { attributes, setAttributes } = this.props;
-		const { shortcode_tag } = this.shortcode;
-		const value = attributes[ attr ] || '';
-
-		const updateValue = e => {
-			setAttributes( { [ attr ]: e.target.value } );
-		}
-
-		return (
-			<section key={ `shortcode-${shortcode_tag}-${attr}` } className='shortcode-ui-block-inspector-form-item'>
-				<label className='shortcode-ui-block-inspector-form-item-label'>{ label }</label>
-				<input className='shortcode-ui-block-inspector-form-item-input'
-					type='text'
-					name={ attr }
-					value={ value }
-					onChange={ updateValue }
-					/>
-				{ description.length && (
-					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
-				) }
-			</section>
-		);
-	};
 }
 
 export default EditBlock;

--- a/src/EditBlock.js
+++ b/src/EditBlock.js
@@ -39,11 +39,11 @@ class EditBlock extends Component {
 	/**
 	 * When props update, update the shortcode string and re-fetch the preview.
 	 */
-	//componentWillReceiveProps( nextProps ) {
-		//if ( nextProps && nextProps !== this.props ) {
-			//this.maybeUpdatePreview();
-		//}
-	//}
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps && nextProps !== this.props ) {
+			this.maybeUpdatePreview();
+		}
+	}
 
 	/**
 	 * Fetch a new preview in response to a change in shortcode attributes.

--- a/src/EditBlock.js
+++ b/src/EditBlock.js
@@ -39,11 +39,11 @@ class EditBlock extends Component {
 	/**
 	 * When props update, update the shortcode string and re-fetch the preview.
 	 */
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps && nextProps !== this.props ) {
-			this.maybeUpdatePreview();
-		}
-	}
+	//componentWillReceiveProps( nextProps ) {
+		//if ( nextProps && nextProps !== this.props ) {
+			//this.maybeUpdatePreview();
+		//}
+	//}
 
 	/**
 	 * Fetch a new preview in response to a change in shortcode attributes.
@@ -105,7 +105,11 @@ class EditBlock extends Component {
 				(
 					<div className="wp-block-shortcake-preview" key="preview" style={ focus && { minHeight: this.state.minHeight } }>
 						<SandBox html={ preview } title={ `${label} shortcode preview` } type={ shortcode_tag } />
-						<div className={ "wp-block-shortcake-preview-overlay" + ( focus ? ' editing' : '' ) } onClick={ setFocus } onFocus={ setFocus } >
+						<div className={ "wp-block-shortcake-preview-overlay" + ( focus ? ' editing' : '' ) }
+							onClick={ setFocus }
+							onFocus={ setFocus }
+							onBlur={ this.maybeUpdatePreview }
+							>
 							{ focus && (
 								<form title={ `Edit ${label} post element` } className="wp-block-shortcode-edit-form">
 									<h4 className="shortcode-ui-block-editor-title">Edit {label} post element</h4>
@@ -125,7 +129,10 @@ class EditBlock extends Component {
 				// Or the preformatted shortcode text if no preview is available.
 				(
 					<div className="wp-block-shortcake-preview" key="content" style={ focus && { minHeight: this.state.minHeight } }>
-						<code onFocus={ setFocus }>
+						<code
+							onFocus={ setFocus }
+							onBlur={ this.maybeUpdatePreview }
+							>
 							{ content }
 						</code>
 						{ focus && (

--- a/src/ShortcodeEditForm.js
+++ b/src/ShortcodeEditForm.js
@@ -4,7 +4,9 @@ import React from 'react';
 
 import sizeMe from 'react-sizeme';
 
-import EditAttributeField, * as fields from './fields/EditAttributeField';
+import EditAttributeField from './fields/EditAttributeField';
+import * as fields from './fields';
+
 
 const { Component } = wp.element;
 

--- a/src/ShortcodeEditForm.js
+++ b/src/ShortcodeEditForm.js
@@ -1,0 +1,47 @@
+/* global wp: false, _: false */
+
+import React from 'react';
+
+import sizeMe from 'react-sizeme';
+
+import EditAttributeField, * as fields from './fields/EditAttributeField';
+
+const { Component } = wp.element;
+
+class ShortcodeEditForm extends Component {
+
+	render() {
+		const { shortcode, attrs, values, setAttributes } = this.props;
+
+		return (
+			<div className="shortcake-gutenberg-shortcode-edit-form">
+				{
+					attrs.map(
+						attribute => {
+							const { attr, type } = attribute;
+							const { shortcode_tag } = shortcode;
+							const { [ attr ]: value } = values;
+
+							// Select the correct attribute field class from the attribute type.
+							const AttributeField = _.find( fields, ( { attrType } ) => attrType === type ) || EditAttributeField;
+
+							return (
+								<AttributeField
+									key={ `shortcode-${shortcode_tag}-attr-${attr}` }
+									value={ value }
+									attribute={ attribute }
+									shortcode={ shortcode }
+									updateValue={ newValue => setAttributes( { [ attr ]: newValue } ) }
+									/>
+							);
+						}
+					)
+				}
+			</div>
+		);
+	}
+
+}
+
+//export default ShortcodeEditForm;
+export default sizeMe( { monitorHeight: true } )( ShortcodeEditForm );

--- a/src/fields/ColorField.js
+++ b/src/fields/ColorField.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { ChromePicker } from 'react-color';
+
+import EditAttributeField from './EditAttributeField';
+
+export default class ColorField extends EditAttributeField {
+	static attrType = 'color';
+
+	render() {
+		const { attribute, value, updateValue } = this.props;
+		const { attr, label, description } = attribute;
+
+		return (
+			<section className='shortcode-ui-block-inspector-form-item'>
+				<label className='shortcode-ui-block-inspector-form-item-label'>{ label }</label>
+				<ChromePicker
+					name={ attr }
+					color={ value }
+					onChangeComplete={ ( color ) => updateValue( color.hex ) }
+					style={ { width: '100%' } }
+					disableAlpha
+				/>
+				{ description && description.length && (
+					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
+				) }
+			</section>
+		);
+
+	}
+}

--- a/src/fields/EditAttributeField.js
+++ b/src/fields/EditAttributeField.js
@@ -1,4 +1,4 @@
-/* global wp: false */
+/* global wp: false, _: false */
 
 import React from 'react';
 import TextareaAutosize from 'react-autosize-textarea';
@@ -67,8 +67,8 @@ export class DateField extends EditAttributeField {
 };
 
 export class ColorField extends EditAttributeField {
-	static attrType = 'date';
-	addlAttrs = { type: 'date' };
+	static attrType = 'color';
+	addlAttrs = { type: 'color' };
 };
 
 export class TextArea extends EditAttributeField {
@@ -96,24 +96,42 @@ export class TextArea extends EditAttributeField {
 	};
 }
 
-export class SelectFIeld extends EditAttributeField {
-	//static attrType = 'select';
+export class SelectField extends EditAttributeField {
+	static attrType = 'select';
 
 	render() {
 		const { attribute, shortcode, value, updateValue } = this.props;
-		const { attr, label, description, options, meta } = attribute;
+		const { attr, label, description, options, meta = {} } = attribute;
+		const { multiple = false } = meta;
 		const { shortcode_tag } = shortcode;
 
 		return (
 			<section key={ `shortcode-${shortcode_tag}-${attr}` } className='shortcode-ui-block-inspector-form-item'>
 				<label className='shortcode-ui-block-inspector-form-item-label'>{ label }</label>
-				<Select className='shortcode-ui-block-inspector-form-item-input'
-					{ ...meta }
+				<select
 					name={ attr }
 					value={ value }
-					options={ options }
-					onChange={ updateValue }
-				/>
+					onChange={ ( { target: { value: newValue } } ) => updateValue( newValue ) } >
+					{ options.map(
+						option => {
+							if ( 'options' in option ) {
+								return (
+									<optgroup label={ option.label } key={ option.label } >
+									{ option.options.map(
+										option => (
+											<option key={ option.value } value={ option.value } >{ option.label }</option>
+										)
+									) }
+									</optgroup>
+								);
+							} else {
+								return (
+									<option key={ option.value } value={ option.value } >{ option.label }</option>
+								)
+							}
+						} )
+					}
+				</select>
 				{ description && description.length && (
 					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
 				) }

--- a/src/fields/EditAttributeField.js
+++ b/src/fields/EditAttributeField.js
@@ -1,6 +1,8 @@
 /* global wp: false */
 
 import React from 'react';
+import TextareaAutosize from 'react-autosize-textarea';
+import Select from 'react-select';
 
 const { Component } = wp.element;
 
@@ -13,28 +15,28 @@ const { Component } = wp.element;
 class EditAttributeField extends Component {
 
 	/**
-	 * Render a text input for an attribute value field.
+	 * Object of additional attributes which are set on the input field.
 	 *
-	 * TODO: This should be moved to a different component so that we
-	 * can define multiple input types. Currently all attribute fields
-	 * are displayed as text inputs, no matter what field type was
-	 * registered for them.
+	 */
+	addlAttrs = {};
+
+	/**
+	 * Render an input element for an attribute value field.
 	 */
 	render() {
-		const { attribute, shortcode, value, updateValue } = this.props;
+		const { attribute, value, updateValue } = this.props;
 		const { attr, label, description } = attribute;
-		const { shortcode_tag } = shortcode;
 
 		return (
-			<section key={ `shortcode-${shortcode_tag}-${attr}` } className='shortcode-ui-block-inspector-form-item'>
+			<section className='shortcode-ui-block-inspector-form-item'>
 				<label className='shortcode-ui-block-inspector-form-item-label'>{ label }</label>
 				<input className='shortcode-ui-block-inspector-form-item-input'
-					type='text'
+					{ ...this.addlAttrs }
 					name={ attr }
 					value={ value }
-					onChange={ updateValue }
+					onChange={ e => updateValue( e.target.value ) }
 					/>
-				{ description.length && (
+				{ description && description.length && (
 					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
 				) }
 			</section>
@@ -43,3 +45,79 @@ class EditAttributeField extends Component {
 }
 
 export default EditAttributeField;
+
+export class TextField extends EditAttributeField {
+	static attrType = 'text';
+	addlAttrs = { type: 'text' };
+};
+
+export class UrlField extends EditAttributeField {
+	static attrType = 'url';
+	addlAttrs = { type: 'url' };
+};
+
+export class EmailField extends EditAttributeField {
+	static attrType = 'email';
+	addlAttrs = { type: 'email' };
+};
+
+export class DateField extends EditAttributeField {
+	static attrType = 'date';
+	addlAttrs = { type: 'date' };
+};
+
+export class ColorField extends EditAttributeField {
+	static attrType = 'date';
+	addlAttrs = { type: 'date' };
+};
+
+export class TextArea extends EditAttributeField {
+	static attrType = 'textarea';
+
+	render() {
+		const { attribute, shortcode, value, updateValue } = this.props;
+		const { attr, label, description } = attribute;
+		const { shortcode_tag } = shortcode;
+
+		return (
+			<section key={ `shortcode-${shortcode_tag}-${attr}` } className='shortcode-ui-block-inspector-form-item'>
+				<label className='shortcode-ui-block-inspector-form-item-label'>{ label }</label>
+				<TextareaAutosize className='shortcode-ui-block-inspector-form-item-input'
+					type='text'
+					name={ attr }
+					value={ value }
+					onChange={ e => updateValue( e.target.value ) }
+					/>
+				{ description && description.length && (
+					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
+				) }
+			</section>
+		);
+	};
+}
+
+export class SelectFIeld extends EditAttributeField {
+	//static attrType = 'select';
+
+	render() {
+		const { attribute, shortcode, value, updateValue } = this.props;
+		const { attr, label, description, options, meta } = attribute;
+		const { shortcode_tag } = shortcode;
+
+		return (
+			<section key={ `shortcode-${shortcode_tag}-${attr}` } className='shortcode-ui-block-inspector-form-item'>
+				<label className='shortcode-ui-block-inspector-form-item-label'>{ label }</label>
+				<Select className='shortcode-ui-block-inspector-form-item-input'
+					{ ...meta }
+					name={ attr }
+					value={ value }
+					options={ options }
+					onChange={ updateValue }
+				/>
+				{ description && description.length && (
+					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
+				) }
+			</section>
+		);
+	};
+}

--- a/src/fields/EditAttributeField.js
+++ b/src/fields/EditAttributeField.js
@@ -171,15 +171,16 @@ export class RadioField extends EditAttributeField {
 		const { attribute, shortcode, value, updateValue } = this.props;
 		const { attr, label, description, options } = attribute;
 		const { shortcode_tag } = shortcode;
+		const onChange = evt => updateValue( evt.target.value );
 
 		return (
 			<section key={ `shortcode-${shortcode_tag}-${attr}` } className="shortcode-ui-block-inspector-form-item">
-				<label class="shortcode-ui-block-inspector-form-item-label">{ label }</label>
-				<div class="shortcode-ui-form-radio-options-wrapper">
+				<label className="shortcode-ui-block-inspector-form-item-label">{ label }</label>
+				<div className="shortcode-ui-form-radio-options-wrapper">
 					{ options.map(
 						option => (
-							<label className="shortcode-ui-form-radio-option-label">
-								<input type="radio" name={ attr } value={ option.value } checked={ option.value === value } onClick={ () => updateValue( option.value ) } />
+							<label key={ `option-${option.value}` } className="shortcode-ui-form-radio-option-label">
+								<input type="radio" name={ attr } value={ option.value } checked={ option.value === value } onChange={ onChange } />
 								{ option.label }
 							</label>
 						)
@@ -202,11 +203,14 @@ export class RangeField extends EditAttributeField {
 		const { attr, label, description, meta = {} } = attribute;
 		const { shortcode_tag } = shortcode;
 
+		const onChange = evt => updateValue( evt.target.value );
+
 		return (
 			<section key={ `shortcode-${shortcode_tag}-${attr}` } className="shortcode-ui-block-inspector-form-item">
-				<label class="shortcode-ui-block-inspector-form-item-label">{ label }</label>
-				<div class="shortcode-ui-form-radio-options-wrapper">
-					<input type="range" name={ attr } value={ value} onChange={ () => updateValue( this.value ) } { ...meta } />
+				<label className="shortcode-ui-block-inspector-form-item-label">{ label }</label>
+				<div className="shortcode-ui-form-range-field-wrapper">
+					<input className="shortcode-ui-form-range-input" type="range" name={ attr } value={ value } onChange={ onChange } { ...meta } />
+					<span className="shortcode-ui-form-range-label">{ value }</span>
 				</div>
 				{ description && description.length && (
 					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>

--- a/src/fields/EditAttributeField.js
+++ b/src/fields/EditAttributeField.js
@@ -193,3 +193,25 @@ export class RadioField extends EditAttributeField {
 
 	}
 }
+
+export class RangeField extends EditAttributeField {
+	static attrType = 'range';
+
+	render() {
+		const { attribute, shortcode, value, updateValue } = this.props;
+		const { attr, label, description, meta = {} } = attribute;
+		const { shortcode_tag } = shortcode;
+
+		return (
+			<section key={ `shortcode-${shortcode_tag}-${attr}` } className="shortcode-ui-block-inspector-form-item">
+				<label class="shortcode-ui-block-inspector-form-item-label">{ label }</label>
+				<div class="shortcode-ui-form-radio-options-wrapper">
+					<input type="range" name={ attr } value={ value} onChange={ () => updateValue( this.value ) } { ...meta } />
+				</div>
+				{ description && description.length && (
+					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
+				) }
+			</section>
+		);
+	}
+}

--- a/src/fields/EditAttributeField.js
+++ b/src/fields/EditAttributeField.js
@@ -61,6 +61,11 @@ export class EmailField extends EditAttributeField {
 	addlAttrs = { type: 'email' };
 };
 
+export class NumberField extends EditAttributeField {
+	static attrType = 'number';
+	addlAttrs = { type: 'number' };
+};
+
 export class DateField extends EditAttributeField {
 	static attrType = 'date';
 	addlAttrs = { type: 'date' };
@@ -138,4 +143,64 @@ export class SelectField extends EditAttributeField {
 			</section>
 		);
 	};
+}
+
+export class CheckboxField extends EditAttributeField {
+	static attrType = 'checkbox';
+
+	render() {
+		const { attribute, shortcode, value, updateValue } = this.props;
+		const { attr, label, description, options, meta = {} } = attribute;
+		const { multiple = false } = meta;
+		const { shortcode_tag } = shortcode;
+
+		const toggleChecked = () => updateValue( ! value );
+
+		return (
+			<section key={ `shortcode-${shortcode_tag}-${attr}` } className='shortcode-ui-block-inspector-form-item'>
+				<label className='shortcode-ui-block-inspector-form-item-label' >
+					<input type="checkbox" name={ attr } checked={ !! value } onChange={ toggleChecked } />
+					{ label }
+				</label>
+				{ description && description.length && (
+					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
+				) }
+			</section>
+		);
+
+	}
+}
+
+export class RadioField extends EditAttributeField {
+	static attrType = 'radio';
+
+	render() {
+		const { attribute, shortcode, value, updateValue } = this.props;
+		const { attr, label, description, options, meta = {} } = attribute;
+		const { multiple = false } = meta;
+		const { shortcode_tag } = shortcode;
+
+		const updateSelection = (e) => {
+			console.log( e );
+			updateValue( e.target.value );
+		}
+
+		return (
+			<section key={ `shortcode-${shortcode_tag}-${attr}` } className="shortcode-ui-block-inspector-form-item">
+				<label>{ label }</label>
+				{ options.map(
+					option => (
+						<label>
+							<input type="radio" name={ attr } value={ option.value } checked={ option.value == value } onClick={ () => updateValue( option.value ) } />
+							{ option.label }
+						</label>
+					)
+				) }
+				{ description && description.length && (
+					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
+				) }
+			</section>
+		);
+
+	}
 }

--- a/src/fields/EditAttributeField.js
+++ b/src/fields/EditAttributeField.js
@@ -1,0 +1,45 @@
+/* global wp: false */
+
+import React from 'react';
+
+const { Component } = wp.element;
+
+/**
+ * The most basic attribute field for a shortcode.
+ *
+ * Renders a text input, with the label and description if defined, for a
+ * string attribute value.
+ */
+class EditAttributeField extends Component {
+
+	/**
+	 * Render a text input for an attribute value field.
+	 *
+	 * TODO: This should be moved to a different component so that we
+	 * can define multiple input types. Currently all attribute fields
+	 * are displayed as text inputs, no matter what field type was
+	 * registered for them.
+	 */
+	render() {
+		const { attribute, shortcode, value, updateValue } = this.props;
+		const { attr, label, description } = attribute;
+		const { shortcode_tag } = shortcode;
+
+		return (
+			<section key={ `shortcode-${shortcode_tag}-${attr}` } className='shortcode-ui-block-inspector-form-item'>
+				<label className='shortcode-ui-block-inspector-form-item-label'>{ label }</label>
+				<input className='shortcode-ui-block-inspector-form-item-input'
+					type='text'
+					name={ attr }
+					value={ value }
+					onChange={ updateValue }
+					/>
+				{ description.length && (
+					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
+				) }
+			</section>
+		);
+	};
+}
+
+export default EditAttributeField;

--- a/src/fields/EditAttributeField.js
+++ b/src/fields/EditAttributeField.js
@@ -70,11 +70,6 @@ export class DateField extends EditAttributeField {
 	addlAttrs = { type: 'date' };
 };
 
-export class ColorField extends EditAttributeField {
-	static attrType = 'color';
-	addlAttrs = { type: 'color' };
-};
-
 export class TextArea extends EditAttributeField {
 	static attrType = 'textarea';
 
@@ -183,7 +178,7 @@ export class RadioField extends EditAttributeField {
 				<div class="shortcode-ui-form-radio-options-wrapper">
 					{ options.map(
 						option => (
-							<label class="shortcode-ui-form-radio-option-label">
+							<label className="shortcode-ui-form-radio-option-label">
 								<input type="radio" name={ attr } value={ option.value } checked={ option.value === value } onClick={ () => updateValue( option.value ) } />
 								{ option.label }
 							</label>

--- a/src/fields/EditAttributeField.js
+++ b/src/fields/EditAttributeField.js
@@ -1,8 +1,7 @@
-/* global wp: false, _: false */
+/* global wp: false */
 
 import React from 'react';
 import TextareaAutosize from 'react-autosize-textarea';
-import Select from 'react-select';
 
 const { Component } = wp.element;
 
@@ -107,7 +106,6 @@ export class SelectField extends EditAttributeField {
 	render() {
 		const { attribute, shortcode, value, updateValue } = this.props;
 		const { attr, label, description, options, meta = {} } = attribute;
-		const { multiple = false } = meta;
 		const { shortcode_tag } = shortcode;
 
 		return (
@@ -116,26 +114,27 @@ export class SelectField extends EditAttributeField {
 				<select
 					name={ attr }
 					value={ value }
-					onChange={ ( { target: { value: newValue } } ) => updateValue( newValue ) } >
-					{ options.map(
-						option => {
-							if ( 'options' in option ) {
-								return (
-									<optgroup label={ option.label } key={ option.label } >
-									{ option.options.map(
-										option => (
-											<option key={ option.value } value={ option.value } >{ option.label }</option>
-										)
-									) }
-									</optgroup>
-								);
-							} else {
-								return (
-									<option key={ option.value } value={ option.value } >{ option.label }</option>
-								)
-							}
-						} )
-					}
+					onChange={ ( { target: { value: newValue } } ) => updateValue( newValue ) }
+					{ ...meta } >
+						{ options.map(
+							option => {
+								if ( 'options' in option ) {
+									return (
+										<optgroup label={ option.label } key={ option.label } >
+										{ option.options.map(
+											option => (
+												<option key={ option.value } value={ option.value } >{ option.label }</option>
+											)
+										) }
+										</optgroup>
+									);
+								} else {
+									return (
+										<option key={ option.value } value={ option.value } >{ option.label }</option>
+									)
+								}
+							} )
+						}
 				</select>
 				{ description && description.length && (
 					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
@@ -150,8 +149,7 @@ export class CheckboxField extends EditAttributeField {
 
 	render() {
 		const { attribute, shortcode, value, updateValue } = this.props;
-		const { attr, label, description, options, meta = {} } = attribute;
-		const { multiple = false } = meta;
+		const { attr, label, description, meta = {} } = attribute;
 		const { shortcode_tag } = shortcode;
 
 		const toggleChecked = () => updateValue( ! value );
@@ -159,7 +157,7 @@ export class CheckboxField extends EditAttributeField {
 		return (
 			<section key={ `shortcode-${shortcode_tag}-${attr}` } className='shortcode-ui-block-inspector-form-item'>
 				<label className='shortcode-ui-block-inspector-form-item-label' >
-					<input type="checkbox" name={ attr } checked={ !! value } onChange={ toggleChecked } />
+					<input type="checkbox" name={ attr } checked={ !! value } onChange={ toggleChecked } { ...meta } />
 					{ label }
 				</label>
 				{ description && description.length && (
@@ -176,26 +174,22 @@ export class RadioField extends EditAttributeField {
 
 	render() {
 		const { attribute, shortcode, value, updateValue } = this.props;
-		const { attr, label, description, options, meta = {} } = attribute;
-		const { multiple = false } = meta;
+		const { attr, label, description, options } = attribute;
 		const { shortcode_tag } = shortcode;
-
-		const updateSelection = (e) => {
-			console.log( e );
-			updateValue( e.target.value );
-		}
 
 		return (
 			<section key={ `shortcode-${shortcode_tag}-${attr}` } className="shortcode-ui-block-inspector-form-item">
-				<label>{ label }</label>
-				{ options.map(
-					option => (
-						<label>
-							<input type="radio" name={ attr } value={ option.value } checked={ option.value == value } onClick={ () => updateValue( option.value ) } />
-							{ option.label }
-						</label>
-					)
-				) }
+				<label class="shortcode-ui-block-inspector-form-item-label">{ label }</label>
+				<div class="shortcode-ui-form-radio-options-wrapper">
+					{ options.map(
+						option => (
+							<label class="shortcode-ui-form-radio-option-label">
+								<input type="radio" name={ attr } value={ option.value } checked={ option.value === value } onClick={ () => updateValue( option.value ) } />
+								{ option.label }
+							</label>
+						)
+					) }
+				</div>
 				{ description && description.length && (
 					<span className='shortcode-ui-block-inspector-form-item-description'>{ description }</span>
 				) }

--- a/src/fields/index.js
+++ b/src/fields/index.js
@@ -1,0 +1,14 @@
+export {
+	TextField,
+	UrlField,
+	EmailField,
+	NumberField,
+	DateField,
+	TextArea,
+	SelectField,
+	CheckboxField,
+	RadioField
+} from './EditAttributeField';
+
+
+export { default as ColorField } from './ColorField';

--- a/src/fields/index.js
+++ b/src/fields/index.js
@@ -7,7 +7,8 @@ export {
 	TextArea,
 	SelectField,
 	CheckboxField,
-	RadioField
+	RadioField,
+	RangeField
 } from './EditAttributeField';
 
 

--- a/src/utils/mapItemImage.js
+++ b/src/utils/mapItemImage.js
@@ -11,6 +11,10 @@ import React from 'react';
  * @return {String|wp.element}            The slug portion of the dashicon class or a wp.element which renders an image.
  */
 const mapItemImage = shortcodeListItemImage => {
+	if ( ! shortcodeListItemImage ) {
+		return 'marker';
+	}
+
 	if ( shortcodeListItemImage.startsWith( 'dashicons-' ) ) {
 		return shortcodeListItemImage.replace( 'dashicons-', '' );
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3991,7 +3991,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-"lodash@>=3.5 <5", lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4050,6 +4050,10 @@ makeerror@1.0.x:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+material-colors@^1.2.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.5.tgz#5292593e6754cb1bcc2b98030e4e0d6a3afc9ea1"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -5155,6 +5159,16 @@ react-autosize-textarea@^3.0.1:
     line-height "^0.3.1"
     prop-types "^15.5.6"
 
+react-color@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.13.8.tgz#bcc58f79a722b9bfc37c402e68cd18f26970aee4"
+  dependencies:
+    lodash "^4.0.1"
+    material-colors "^1.2.1"
+    prop-types "^15.5.10"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.4.1"
+
 react-dev-utils@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.1.tgz#9f2763e7bafa1a1b9c52254d2a479deec280f111"
@@ -5257,6 +5271,12 @@ react@^16.2.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+reactcss@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
+  dependencies:
+    lodash "^4.0.1"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -6111,6 +6131,10 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
   dependencies:
     setimmediate "^1.0.4"
+
+tinycolor2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
 
 tmp@^0.0.33:
   version "0.0.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,10 +1349,6 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.4:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-
 clean-css@4.1.x:
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
@@ -5024,7 +5020,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -5195,12 +5191,6 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
-react-input-autosize@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.1.2.tgz#a3dc11a5517c434db25229925541309de3f7a8f5"
-  dependencies:
-    prop-types "^15.5.8"
-
 react-scripts@1.0.17:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-1.0.17.tgz#c30029123b561a060227af4d7797d50a222d3fbf"
@@ -5243,14 +5233,6 @@ react-scripts@1.0.17:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "1.1.2"
-
-react-select@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.1.0.tgz#626a2de839fdea2ade74dd1b143a9bde34be6c82"
-  dependencies:
-    classnames "^2.2.4"
-    prop-types "^15.5.8"
-    react-input-autosize "^2.1.0"
 
 react-sizeme@^2.3.6:
   version "2.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@types/autosize@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/autosize/-/autosize-3.0.6.tgz#9022e6a783ec5a4d5e570013701dbc0bfe7667fa"
+  dependencies:
+    "@types/jquery" "*"
+
+"@types/jquery@*":
+  version "3.2.17"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.2.17.tgz#01df9805dd5cf83a14cf5bfd81adced7d4fbd970"
+
+"@types/prop-types@15.5.2":
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"
+
+"@types/react@16.0.30":
+  version "16.0.30"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.30.tgz#cca9b180160004df574519c3d7c559fb181d545f"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -295,6 +313,10 @@ autoprefixer@^6.3.1:
     num2fraction "^1.2.2"
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
+
+autosize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/autosize/-/autosize-4.0.0.tgz#7a0599b1ba84d73bd7589b0d9da3870152c69237"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -960,6 +982,10 @@ base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
 
+batch-processor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -1323,6 +1349,10 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
+classnames@^2.2.4:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-css@4.1.x:
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
@@ -1444,6 +1474,10 @@ compression@^1.5.2:
     on-headers "~1.0.1"
     safe-buffer "5.1.1"
     vary "~1.1.2"
+
+computed-style@~0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/computed-style/-/computed-style-0.1.4.tgz#7f344fd8584b2e425bedca4a1afc0e300bb05d74"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1981,6 +2015,12 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.28:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
   dependencies:
     electron-releases "^2.1.0"
+
+element-resize-detector@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.12.tgz#8b3fd6eedda17f9c00b360a0ea2df9927ae80ba2"
+  dependencies:
+    batch-processor "^1.0.0"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -3858,6 +3898,12 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+line-height@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/line-height/-/line-height-0.3.1.tgz#4b1205edde182872a5efa3c8f620b3187a9c54c9"
+  dependencies:
+    computed-style "~0.1.3"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -4978,7 +5024,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -5102,6 +5148,17 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-autosize-textarea@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-3.0.1.tgz#56daa1c4ddfd1de64399c6b00b2c5dafe823e726"
+  dependencies:
+    "@types/autosize" "3.0.6"
+    "@types/prop-types" "15.5.2"
+    "@types/react" "16.0.30"
+    autosize "^4.0.0"
+    line-height "^0.3.1"
+    prop-types "^15.5.6"
+
 react-dev-utils@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.1.tgz#9f2763e7bafa1a1b9c52254d2a479deec280f111"
@@ -5137,6 +5194,12 @@ react-dom@^16.2.0:
 react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
+
+react-input-autosize@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.1.2.tgz#a3dc11a5517c434db25229925541309de3f7a8f5"
+  dependencies:
+    prop-types "^15.5.8"
 
 react-scripts@1.0.17:
   version "1.0.17"
@@ -5180,6 +5243,22 @@ react-scripts@1.0.17:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "1.1.2"
+
+react-select@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.1.0.tgz#626a2de839fdea2ade74dd1b143a9bde34be6c82"
+  dependencies:
+    classnames "^2.2.4"
+    prop-types "^15.5.8"
+    react-input-autosize "^2.1.0"
+
+react-sizeme@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.3.6.tgz#d60ea2634acc3fd827a3c7738d41eea0992fa678"
+  dependencies:
+    element-resize-detector "^1.1.12"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
 
 react-wp-scripts@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Defines a base class essentially analogous to Shortcake's `editAttributeField` which contains the minimum functionality necessary to render an attribute field view, and begin creating subclasses for each of the attribute types enables in Shortcake.

See #1.