### PR TITLE
Prevent invalid block name errors for shortcodes with underscores

### DIFF
--- a/src/registerShortcodeBlock.js
+++ b/src/registerShortcodeBlock.js
@@ -15,7 +15,9 @@ const registerShortcodeBlock = function( shortcode ) {
 
 	const { shortcode_tag, attrs, listItemImage, label } = shortcode;
 
-	registerBlockType( `shortcake/${shortcode_tag}`,
+	const sanitizedBlockName = shortcode_tag.toLowerCase().replace( /[^a-z0-9-]+/g, '-' );
+
+	registerBlockType( `shortcake/${sanitizedBlockName}`,
 		{
 			title: label,
 


### PR DESCRIPTION
Gutenberg block can only contain alphanumeric characters and dashes, and
must begin with a prefix. Since shortcodes can also contain underscores,
some shortcodes will lead to invalid block names, which causes fatal
js errors. This prevents that problem by sanitizing the block names when
registering them.